### PR TITLE
Add dependency required for `rfd` crate to CI build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - run: sudo apt install libgtk-3-dev
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -50,7 +51,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev
+      - run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libgtk-3-dev
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -83,6 +84,7 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
+      - run: sudo apt install libgtk-3-dev
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "slam",
 ]
 default-members = ["baseui"]
+resolver = "2"
 
 
 [workspace.dependencies]


### PR DESCRIPTION
The `rfd` crate depends on `gdk-sys` which in turn requires the gtk3 development libraries to be installed. This caused the CI to fail as it was not installed during the workflow. With this PR that has been fixed by installing `libgtk-3-dev` for each of the steps that build the project :rocket: 
