### PR TITLE
Add Neato LIDAR serial connection as option in config

### DIFF
--- a/baseui/src/config.rs
+++ b/baseui/src/config.rs
@@ -13,7 +13,7 @@ use crate::node::{
 };
 
 #[cfg(not(target_arch = "wasm32"))]
-use neato::FileLoaderNodeConfig;
+use neato::{FileLoaderNodeConfig, SerialConnectionNodeConfig};
 
 #[derive(Clone, Deserialize, Default)]
 pub struct Config {
@@ -35,6 +35,8 @@ pub enum NodeEnum {
     ShapeTest(ShapeRenderingNodeConfig),
     #[cfg(not(target_arch = "wasm32"))]
     FileLoader(FileLoaderNodeConfig),
+    #[cfg(not(target_arch = "wasm32"))]
+    SerialConnection(SerialConnectionNodeConfig),
     IcpPointMapper(IcpPointMapNodeConfig),
     Visualizer(FrameVizualizerNodeConfig),
     GridMapSlam(GridMapSlamNodeConfig),
@@ -50,6 +52,8 @@ impl NodeEnum {
             ShapeTest(c) => c.instantiate(pubsub),
             #[cfg(not(target_arch = "wasm32"))]
             FileLoader(c) => c.instantiate(pubsub),
+            #[cfg(not(target_arch = "wasm32"))]
+            SerialConnection(c) => c.instantiate(pubsub),
             IcpPointMapper(c) => c.instantiate(pubsub),
             Visualizer(c) => c.instantiate(pubsub),
             GridMapSlam(c) => c.instantiate(pubsub),

--- a/baseui/src/editor.rs
+++ b/baseui/src/editor.rs
@@ -28,6 +28,7 @@ nodes:
             presets: vec![
                 ("Shape Test", include_str!("../../config/shape_test.yaml")),
                 ("Grid Slam", include_str!("../../config/grid_slam.yaml")),
+                ("Neato ICP", include_str!("../../config/neato.yaml")),
             ],
             parsed_config: None,
         };

--- a/config/neato.yaml
+++ b/config/neato.yaml
@@ -1,0 +1,64 @@
+
+settings:
+  headless: false
+
+nodes:
+
+- !MousePosition
+
+# - !ShapeTest
+
+- !SerialConnection
+  topic_observation: "robot/observation"
+
+- !FileLoader
+  topic_observation: "robot/observation"
+  topic_pose: "robot/pose"
+  
+- !Controls
+  topic_command: "robot/command"
+  keyboard_enabled: true
+  max_speed: 0.1
+
+- !IcpPointMapper
+  topic_observation: "robot/observation"
+  topic_pose: "robot/pose"
+  topic_pointmap: "slam/map"
+  icp:
+    iterations: 10
+    correspondence_weights: !Step {threshold: 0.05}
+
+- !Visualizer
+  topics:
+  
+  - !PointMap
+    topic: "slam/map"
+    config:
+      size: 0.01
+      point_color: [0.0, 1.0, 0.0]
+    
+  - !Observation
+    topic: "robot/observation"
+    topic_pose: "robot/pose"
+    config:
+      draw_lines: true
+      size: 0.01
+      point_color: [0.0, 1.0, 0.0]
+
+  - !Pose
+    topic: "robot/pose"
+    config:
+      color: [0.0, 1.0, 1.0]
+      radius: 0.1
+
+  
+
+
+#   scanner:
+#     rate: 5
+#     fov: 360
+
+# - IcpPointMapper
+#   icp_threshold: 300
+
+        

--- a/neato/src/lib.rs
+++ b/neato/src/lib.rs
@@ -1,6 +1,6 @@
 mod serial;
 
-pub use serial::SerialConnection;
+pub use serial::{SerialConnection, SerialConnectionNodeConfig};
 
 mod frame;
 


### PR DESCRIPTION
Previously, the `SerialConnection` node was not instantiatable through the configuration file since it was not included in the config enum. This PR fixes that and makes sure `wasm` targets are handled properly, i.e., by not being available on those platforms. Also added an example configuration that includes the serial connection node to the presets and an implementation of `Drop` such that the serial thread is shutdown correctly if the user exits the program :fire: 