### PR TITLE
Update workflow to only run when necessary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 name: CI
 


### PR DESCRIPTION
The workflow was being triggered twice and once for each push, even for feature branches. This change restricts that to only run on pushes to the main branch (eg. after a merge) and on pull requests into main :fire: 