### PR TITLE
Move away from unmaintained action

### DIFF
--- a/.github/workflows/slamrs_pages.yml
+++ b/.github/workflows/slamrs_pages.yml
@@ -27,17 +27,17 @@ jobs:
   build-github-pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # repo checkout
-      - uses: actions-rs/toolchain@v1 # get rust toolchain for wasm
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
+          targets: wasm32-unknown-unknown
+
       - name: Rust Cache # cache the rust build artefacts
         uses: Swatinem/rust-cache@v2
+
       - name: Download and install Trunk binary
         run: wget -qO- https://github.com/thedodd/trunk/releases/latest/download/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
+
       - name: Build # build
         # "${GITHUB_REPOSITORY#*/}" evaluates into the name of the repository
         # using --public-url something will allow trunk to modify all the href paths like from favicon.ico to repo_name/favicon.ico .

--- a/.github/workflows/slamrs_rust.yml
+++ b/.github/workflows/slamrs_rust.yml
@@ -23,11 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          components: clippy
+          
       - name: Install dependencies
         run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libgtk-3-dev
         
@@ -50,12 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
+          components: clippy
+          targets: wasm32-unknown-unknown
+
       - name: Rust Cache # cache the rust build artefacts
         uses: Swatinem/rust-cache@v2
         with:
@@ -72,58 +70,13 @@ jobs:
       - name: Lint
         run: cargo clippy --target wasm32-unknown-unknown -- -D warnings
 
-  # test:
-  #   name: Test Suite
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: stable
-  #         override: true
-  #     - run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libgtk-3-dev
-  #     - run: cargo test --lib
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
+
       - run: cargo fmt --all -- --check
-
-  # clippy:
-  #   name: Clippy
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: stable
-  #         override: true
-  #         components: clippy
-  #     - run: sudo apt install libgtk-3-dev
-  #     - run: cargo clippy -- -D warnings
-
-  # trunk:
-  #   name: trunk
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: 1.71.0
-  #         target: wasm32-unknown-unknown
-  #         override: true
-  #     - name: Download and install Trunk binary
-  #       run: wget -qO- https://github.com/thedodd/trunk/releases/latest/download/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
-  #     - name: Build
-  #       run: ./trunk build baseui/index.html


### PR DESCRIPTION
As mentioned in https://github.com/actions-rs/toolchain/issues/216, the currently used action has been unmaintained for many years. This PR switches that to use `dtolnay/rust-toolchain` instead :robot: 