### PR TITLE
Add neato lidar serial support

### DIFF
--- a/slamrs-message/src/lib.rs
+++ b/slamrs-message/src/lib.rs
@@ -11,7 +11,14 @@ pub enum CommandMessage {
     Ping,
     NeatoOn,
     NeatoOff,
-    Drive { left: f32, right: f32 },
+    /// Set downampling factor to only report every n-th scan frame
+    SetDownsampling {
+        every: u8,
+    },
+    Drive {
+        left: f32,
+        right: f32,
+    },
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/slamrs-robot-rtic/firmware/src/main.rs
+++ b/slamrs-robot-rtic/firmware/src/main.rs
@@ -75,7 +75,7 @@ mod app {
         rtic_sync::channel::Receiver<'static, EspMessage, ESP_CHANNEL_CAPACITY>;
 
     const DATA_CHANNEL_CAPACITY: usize = 16;
-    const DATA_PACKET_SIZE: usize = 64;
+    pub const DATA_PACKET_SIZE: usize = 64;
 
     const ROBOT_MESSAGE_CAPACITY: usize = 16;
 
@@ -143,6 +143,11 @@ mod app {
             rtic_sync::channel::Receiver<'static, RobotMessage, ROBOT_MESSAGE_CAPACITY>,
 
         usb_event_sender: rtic_sync::channel::Sender<'static, Event, EVENT_CHANNEL_CAPACITY>,
+        usb_data_sender: rtic_sync::channel::Sender<
+            'static,
+            (usize, [u8; DATA_PACKET_SIZE]),
+            DATA_CHANNEL_CAPACITY,
+        >,
 
         /// The USB Device Driver (shared with the interrupt).
         usb_device: UsbDevice<'static, hal::usb::UsbBus>,
@@ -350,9 +355,10 @@ mod app {
                 event_receiver,
                 data_event_sender: event_sender.clone(),
                 data_receiver,
-                esp_data_sender: data_sender,
+                esp_data_sender: data_sender.clone(),
                 robot_message_sender: robot_message_sender.clone(),
                 robot_message_receiver,
+                usb_data_sender: data_sender,
                 usb_event_sender: event_sender,
                 usb_device,
                 robot_message_sender_usb: robot_message_sender_usb.clone(),
@@ -526,6 +532,7 @@ mod app {
             local = [
                 usb_device,
                 usb_event_sender,
+                usb_data_sender,
             ],
         )]
         fn usb_irq(cx: usb_irq::Context);

--- a/slamrs-robot-rtic/firmware/src/tasks/esp.rs
+++ b/slamrs-robot-rtic/firmware/src/tasks/esp.rs
@@ -48,7 +48,7 @@ pub async fn init_esp(cx: init_esp::Context<'_>) {
             value = cx.local.robot_message_receiver.recv().fuse() => {
                 if let Ok(value) = value {
                     info!("Sending: {:?}", value);
-                    let mut buffer = [0u8;64];
+                    let mut buffer = [0u8;2048];
                     match library::slamrs_message::bincode::encode_into_slice(value, &mut buffer, library::slamrs_message::bincode::config::standard()) {
                         Ok(len) => {
                             let mut len_buffer = [0u8; 10];

--- a/slamrs-robot-rtic/firmware/src/tasks/esp.rs
+++ b/slamrs-robot-rtic/firmware/src/tasks/esp.rs
@@ -1,4 +1,4 @@
-use defmt::{info, warn};
+use defmt::{error, info, warn};
 use embedded_hal::digital::v2::OutputPin;
 use futures::FutureExt;
 use library::{
@@ -33,14 +33,13 @@ pub async fn init_esp(cx: init_esp::Context<'_>) {
 
     cx.local.uart1_tx.write_full_blocking(b"AT+CWSTATE?\r\n");
 
-    enum State {
-        Ready,
-        WifiConnectedAndIp,
-        Listening,
-        ClientConnected,
-    }
-
-    let mut state = State::Ready;
+    // enum State {
+    //     Ready,
+    //     WifiConnectedAndIp,
+    //     Listening,
+    //     ClientConnected,
+    // }
+    // let mut state = State::Ready;
 
     info!("Done, starting message loop");
     loop {
@@ -63,7 +62,7 @@ pub async fn init_esp(cx: init_esp::Context<'_>) {
                             wait_for_message(cx.local.esp_receiver, EspMessage::SendOk).await;
                         }
                         Err(_e) => {
-                            warn!("Error encoding message");
+                            error!("Error encoding message");
                         }
                     }
                 }
@@ -73,7 +72,7 @@ pub async fn init_esp(cx: init_esp::Context<'_>) {
                     info!("Got message: {}", m);
                     match m {
                         EspMessage::GotIP => {
-                            state = State::WifiConnectedAndIp;
+                            // state = State::WifiConnectedAndIp;
                             // enable mdns
                             cx.local
                                 .uart1_tx
@@ -97,15 +96,15 @@ pub async fn init_esp(cx: init_esp::Context<'_>) {
                                 .write_full_blocking(b"AT+CIPSERVER=1,8080\r\n");
                             wait_for_message(cx.local.esp_receiver, EspMessage::Ok).await;
 
-                            state = State::Listening;
+                            // state = State::Listening;
                             info!("Listening");
                         }
                         EspMessage::ClientConnect => {
-                            state = State::ClientConnected;
+                            // state = State::ClientConnected;
                             channel_send(cx.local.esp_event_sender, Event::Connected, "ESP");
                         }
                         EspMessage::ClientDisconnect => {
-                            state = State::Listening;
+                            // state = State::Listening;
                             channel_send(cx.local.esp_event_sender, Event::Disconnected, "ESP");
                         }
                         _ => {}

--- a/slamrs-robot-rtic/firmware/src/tasks/esp.rs
+++ b/slamrs-robot-rtic/firmware/src/tasks/esp.rs
@@ -9,7 +9,7 @@ use rp_pico::hal::fugit::ExtU64;
 use rtic_monotonics::rp2040::Timer;
 
 use crate::{
-    app::{init_esp, uart1_esp32},
+    app::{init_esp, uart1_esp32, DATA_PACKET_SIZE},
     util::{channel_send, wait_for_message},
 };
 
@@ -124,7 +124,7 @@ pub fn uart1_esp32(cx: uart1_esp32::Context<'_>) {
         ParsedMessage::ReceivedData(data) => {
             info!("got data: {}", data);
             // this is not very efficient , but it works for now
-            let mut buffer = [0u8; 64];
+            let mut buffer = [0u8; DATA_PACKET_SIZE];
             if data.len() > buffer.len() {
                 warn!("Data too long, ignoring");
                 return;

--- a/slamrs-robot-rtic/firmware/src/tasks/mod.rs
+++ b/slamrs-robot-rtic/firmware/src/tasks/mod.rs
@@ -1,2 +1,3 @@
 pub mod esp;
+pub mod neato;
 pub mod usb;

--- a/slamrs-robot-rtic/firmware/src/tasks/neato.rs
+++ b/slamrs-robot-rtic/firmware/src/tasks/neato.rs
@@ -2,34 +2,73 @@ use crate::{
     app::{neato_motor_control, uart0_neato},
     motor::MotorDirection,
 };
+use core::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use defmt::{info, warn};
-use embedded_hal::serial::Read;
 use library::slamrs_message::{RobotMessage, ScanFrame};
 use rp_pico::hal::fugit::ExtU64;
 use rtic::Mutex;
 use rtic_monotonics::rp2040::Timer;
 
+/// Atomic variables to control the on/off state of the motor and the last measured RPM
+pub static MOTOR_ON: AtomicBool = AtomicBool::new(false);
+pub static LAST_RPM: AtomicU16 = AtomicU16::new(0);
+
 pub async fn neato_motor_control(mut cx: neato_motor_control::Context<'_>) {
-    // start the motor
+    // initialize the motor
     cx.shared.motor_controller.lock(|mc| {
         cx.local
             .neato_motor
             .set_direction(mc, MotorDirection::Forward)
             .unwrap();
-        cx.local.neato_motor.set_speed(mc, 500).unwrap();
     });
 
-    // wait for 1 second
-    Timer::delay(10000.millis()).await;
+    let mut pwm_current: i32 = 0;
+    loop {
+        Timer::delay(200.millis()).await;
 
-    // stop
-    cx.shared.motor_controller.lock(|mc| {
-        cx.local.neato_motor.set_speed(mc, 0).unwrap();
-    });
+        let rpm_target = if MOTOR_ON.load(Ordering::Relaxed) {
+            300
+        } else {
+            0
+        };
+
+        let last_rpm = LAST_RPM.load(Ordering::Relaxed);
+
+        let error = rpm_target as i16 - last_rpm as i16;
+
+        pwm_current += error as i32 / 4;
+
+        // cap the allowed PWM range to 0-90% (in units of 100)
+        // pwm_current = pwm_current.clamp(0, 90 * 100);
+        pwm_current = pwm_current.clamp(0, 4095);
+
+        // scale the PWM value from 0-100 *100 to the range 0-4095
+        // let mut pwm = (pwm_current as u32 * 4095 / (100 * 100)) as u16;
+        let mut pwm = pwm_current as u16;
+
+        if rpm_target == 0 {
+            pwm = 0;
+        }
+
+        cx.shared.motor_controller.lock(|mc| {
+            cx.local.neato_motor.set_speed(mc, pwm).unwrap();
+        });
+
+        info!(
+            "Control, {} rpm, error={}. New PWM = {}",
+            last_rpm, error, pwm
+        );
+    }
 }
 pub fn uart0_neato(cx: uart0_neato::Context<'_>) {
     cx.local.parser.consume(cx.local.uart0_rx_neato, |data| {
-        let rpm = data.parse_rpm();
+        // some exponential smoothing on the raw (*64) RPM value
+        let rpm = data.parse_rpm_raw();
+        *cx.local.rpm_accumulator += rpm as i32 - *cx.local.rpm_average as i32;
+        *cx.local.rpm_average = *cx.local.rpm_accumulator >> 2;
+        let rpm = (*cx.local.rpm_average / 64) as u16;
+        LAST_RPM.store(rpm, core::sync::atomic::Ordering::Relaxed);
+
         info!("neato rpm: {:?}", rpm);
         // TODO: should we add a data validation check?
         if rpm < 250 && rpm > 350 {
@@ -50,5 +89,20 @@ pub fn uart0_neato(cx: uart0_neato::Context<'_>) {
             }),
             "uart0_neato",
         );
+
+        // // need to copy the data to a new array because the data is borrowed from the parser
+        // let mut scan_data = [0; 1980];
+        // scan_data.copy_from_slice(data.data);
+        //
+        // // send frame to the host
+        // crate::util::channel_send(
+        //     cx.local.robot_message_sender_esp_neato,
+        //     RobotMessage::ScanFrame(ScanFrame {
+        //         scan_data,
+        //         odometry: [0.0; 2], // TODO: add odometry
+        //         rpm,
+        //     }),
+        //     "uart0_neato",
+        // );
     });
 }

--- a/slamrs-robot-rtic/firmware/src/tasks/neato.rs
+++ b/slamrs-robot-rtic/firmware/src/tasks/neato.rs
@@ -3,6 +3,8 @@ use crate::{
     motor::MotorDirection,
 };
 use defmt::{info, warn};
+use embedded_hal::serial::Read;
+use library::slamrs_message::{RobotMessage, ScanFrame};
 use rp_pico::hal::fugit::ExtU64;
 use rtic::Mutex;
 use rtic_monotonics::rp2040::Timer;
@@ -18,11 +20,35 @@ pub async fn neato_motor_control(mut cx: neato_motor_control::Context<'_>) {
     });
 
     // wait for 1 second
-    Timer::delay(1000.millis()).await;
+    Timer::delay(10000.millis()).await;
 
     // stop
     cx.shared.motor_controller.lock(|mc| {
         cx.local.neato_motor.set_speed(mc, 0).unwrap();
     });
 }
-pub fn uart0_neato(cx: uart0_neato::Context<'_>) {}
+pub fn uart0_neato(cx: uart0_neato::Context<'_>) {
+    cx.local.parser.consume(cx.local.uart0_rx_neato, |data| {
+        let rpm = data.parse_rpm();
+        info!("neato rpm: {:?}", rpm);
+        // TODO: should we add a data validation check?
+        if rpm < 250 && rpm > 350 {
+            return;
+        }
+
+        // need to copy the data to a new array because the data is borrowed from the parser
+        let mut scan_data = [0; 1980];
+        scan_data.copy_from_slice(data.data);
+
+        // send frame to the host
+        crate::util::channel_send(
+            cx.local.robot_message_sender_neato,
+            RobotMessage::ScanFrame(ScanFrame {
+                scan_data,
+                odometry: [0.0; 2], // TODO: add odometry
+                rpm,
+            }),
+            "uart0_neato",
+        );
+    });
+}

--- a/slamrs-robot-rtic/firmware/src/tasks/neato.rs
+++ b/slamrs-robot-rtic/firmware/src/tasks/neato.rs
@@ -1,0 +1,28 @@
+use crate::{
+    app::{neato_motor_control, uart0_neato},
+    motor::MotorDirection,
+};
+use defmt::{info, warn};
+use rp_pico::hal::fugit::ExtU64;
+use rtic::Mutex;
+use rtic_monotonics::rp2040::Timer;
+
+pub async fn neato_motor_control(mut cx: neato_motor_control::Context<'_>) {
+    // start the motor
+    cx.shared.motor_controller.lock(|mc| {
+        cx.local
+            .neato_motor
+            .set_direction(mc, MotorDirection::Forward)
+            .unwrap();
+        cx.local.neato_motor.set_speed(mc, 500).unwrap();
+    });
+
+    // wait for 1 second
+    Timer::delay(1000.millis()).await;
+
+    // stop
+    cx.shared.motor_controller.lock(|mc| {
+        cx.local.neato_motor.set_speed(mc, 0).unwrap();
+    });
+}
+pub fn uart0_neato(cx: uart0_neato::Context<'_>) {}

--- a/slamrs-robot-rtic/firmware/src/tasks/usb.rs
+++ b/slamrs-robot-rtic/firmware/src/tasks/usb.rs
@@ -63,7 +63,7 @@ pub async fn usb_sender(mut cx: usb_sender::Context<'_>) {
                     continue;
                 }
 
-                let mut buffer = [0u8; 64];
+                let mut buffer = [0u8; 2048];
                 match library::slamrs_message::bincode::encode_into_slice(
                     message,
                     &mut buffer,

--- a/slamrs-robot-rtic/firmware/src/tasks/usb.rs
+++ b/slamrs-robot-rtic/firmware/src/tasks/usb.rs
@@ -1,7 +1,6 @@
 use crate::{app::usb_irq, app::usb_sender, util::channel_send};
 use defmt::{info, warn};
 use library::event::Event;
-use library::slamrs_message::CommandMessage;
 use rtic::mutex_prelude::*;
 use usb_device::prelude::*;
 
@@ -18,9 +17,9 @@ pub fn usb_irq(mut cx: usb_irq::Context) {
         }
         *usb_active = is_connected;
 
-        // Poll the USB driver with all of our supported USB Classes
+        // Poll the USB driver, and publish any received data
         if usb_dev.poll(&mut [serial]) {
-            let mut buf = [0u8; 64];
+            let mut buf = [0u8; crate::app::DATA_PACKET_SIZE];
             match serial.read(&mut buf) {
                 Err(_e) => {
                     // Do nothing
@@ -29,25 +28,7 @@ pub fn usb_irq(mut cx: usb_irq::Context) {
                     // Do nothing
                 }
                 Ok(count) => {
-                    let data = &buf[..count];
-                    match library::slamrs_message::bincode::decode_from_slice::<CommandMessage, _>(
-                        data,
-                        library::slamrs_message::bincode::config::standard(),
-                    ) {
-                        Ok((event, len)) => {
-                            if len != count {
-                                warn!("Data packet was not fully consumed");
-                            }
-                            channel_send(
-                                cx.local.usb_event_sender,
-                                Event::Command(event),
-                                "usb_irq",
-                            );
-                        }
-                        Err(_e) => {
-                            warn!("Failed to deserialize data");
-                        }
-                    }
+                    channel_send(cx.local.usb_data_sender, (count, buf), "usb_irq");
                 }
             }
         }

--- a/slamrs-robot-rtic/library/src/lib.rs
+++ b/slamrs-robot-rtic/library/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(unsafe_code)]
 
 pub mod event;
+pub mod neato;
 pub mod parse_at;
 pub mod util;
 

--- a/slamrs-robot-rtic/library/src/neato.rs
+++ b/slamrs-robot-rtic/library/src/neato.rs
@@ -1,0 +1,86 @@
+use embedded_hal::serial::Read;
+
+enum RunningParserState {
+    LookingForStart { previous_byte: u8 },
+    CollectingBytes { index: usize },
+}
+
+pub struct RunningParser {
+    buffer: [u8; 1980],
+    state: RunningParserState,
+}
+
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct NeatoFrame<'a> {
+    pub data: &'a [u8; 1980],
+}
+
+impl RunningParser {
+    pub const fn new() -> Self {
+        Self {
+            buffer: [0u8; 1980],
+            state: RunningParserState::LookingForStart { previous_byte: 0 },
+        }
+    }
+    pub fn consume<R: Read<u8>>(
+        &mut self,
+        reader: &mut R,
+        mut callback: impl FnMut(NeatoFrame<'_>),
+    ) {
+        loop {
+            match reader.read() {
+                Ok(byte) => {
+                    use RunningParserState::*;
+                    self.state = match self.state {
+                        LookingForStart {
+                            previous_byte: last_byte,
+                        } => {
+                            if last_byte == 0xFA && byte == 0xA0 {
+                                self.buffer[0] = last_byte;
+                                self.buffer[1] = byte;
+                                CollectingBytes { index: 2 }
+                            } else {
+                                LookingForStart {
+                                    previous_byte: byte,
+                                }
+                            }
+                        }
+                        CollectingBytes { index } => {
+                            self.buffer[index] = byte;
+
+                            if index < self.buffer.len() - 1 {
+                                CollectingBytes { index: index + 1 }
+                            } else {
+                                // buffer is full -> parse and return it!
+                                callback(NeatoFrame { data: &self.buffer });
+
+                                // next restart looking for frame start
+                                LookingForStart { previous_byte: 0 }
+                            }
+                        }
+                    };
+                }
+                Err(nb::Error::WouldBlock) => break,
+                Err(nb::Error::Other(_)) => {
+                    // TODO: what to do here? Return?
+                    break;
+                }
+            }
+        }
+    }
+}
+
+impl<'a> NeatoFrame<'a> {
+    /// Parse the raw RPM value (RPM * 64) from the frame
+    pub fn parse_rpm_raw(&self) -> u16 {
+        let rpm_low = self.data[2];
+        let rpm_high = self.data[3];
+
+        ((rpm_high as u16) << 8) | (rpm_low as u16)
+    }
+
+    /// Parse the RPM value from the frame
+    pub fn parse_rpm(&self) -> u16 {
+        self.parse_rpm_raw() / 64
+    }
+}

--- a/slamrs-robot-rtic/library/src/parse_at.rs
+++ b/slamrs-robot-rtic/library/src/parse_at.rs
@@ -144,7 +144,7 @@ impl<const N: usize> AtParser<N> {
 
                         found = true;
                     }
-                    Err(err) => {
+                    Err(_err) => {
                         // error!("Error parsing IPD: {}", err);
                     }
                 }

--- a/slamrs/neato/src/network.rs
+++ b/slamrs/neato/src/network.rs
@@ -8,7 +8,6 @@ use pubsub::{PubSub, Publisher};
 use serde::Deserialize;
 use slamrs_message::{bincode, CommandMessage, RobotMessage};
 use std::{
-    io::Write,
     net::TcpStream,
     sync::{
         atomic::{AtomicBool, Ordering},

--- a/slamrs/neato/src/network.rs
+++ b/slamrs/neato/src/network.rs
@@ -8,6 +8,7 @@ use pubsub::{PubSub, Publisher};
 use serde::Deserialize;
 use slamrs_message::{bincode, CommandMessage, RobotMessage};
 use std::{
+    io::Write,
     net::TcpStream,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -116,16 +117,17 @@ fn open_and_stream(
 
     let mut stream = TcpStream::connect(host)?;
 
-    // stream.write_all(&[b'A'])?;
-    //port.flush()?;
+    bincode::encode_into_std_write(
+        CommandMessage::SetDownsampling { every: 4 },
+        &mut stream,
+        bincode::config::standard(),
+    )?;
+
     bincode::encode_into_std_write(
         CommandMessage::NeatoOn,
         &mut stream,
         bincode::config::standard(),
     )?;
-    // let mut buffer = [0u8; 1024];
-    // let mut parser = RunningParser::new();
-    //
     bincode::encode_into_std_write(
         CommandMessage::Ping,
         &mut stream,
@@ -155,34 +157,9 @@ fn open_and_stream(
             &mut stream,
             bincode::config::standard(),
         )?;
-
-        // println!("Received: {:?}", data);
-
-        // // let (cmd, len):  =
-        // //     bincode::decode_from_slice(&rx_buffer[..], bincode::config::standard())
-        // //         .expect("Could not parse");
-
-        // match stream.read(&mut buffer) {
-        //     Ok(bytes) => {
-        //         println!("{bytes} incoming bytes");
-        //         // for &b in &buffer[..bytes] {
-        //         //     if let Some(f) = parser.update(b) {
-        //         //         // pusblish the frame!
-        //         //         pub_obs.publish(Arc::new(f.into()));
-        //         //     }
-        //         // }
-        //     }
-        //     Err(e) => {
-        //         // skip TimedOut errors
-        //         if e.kind() != std::io::ErrorKind::TimedOut {
-        //             return Err(e.into());
-        //         }
-        //     }
-        // }
     }
 
     // doesn't really matter if this succeeds or not since the connection might be broken already
-    // stream.write_all(&[b'D'])?;
     bincode::encode_into_std_write(
         CommandMessage::NeatoOff,
         &mut stream,

--- a/slamrs/neato/src/serial.rs
+++ b/slamrs/neato/src/serial.rs
@@ -120,6 +120,12 @@ fn open_and_stream(
     println!("Opening {path:?}");
 
     let mut port = SerialPort::open(path, 115200)?;
+    bincode::encode_into_std_write(
+        CommandMessage::SetDownsampling { every: 2 },
+        &mut port,
+        bincode::config::standard(),
+    )?;
+    port.flush()?;
 
     bincode::encode_into_std_write(
         CommandMessage::NeatoOn,


### PR DESCRIPTION
- Copy over and adapt logic from previous robot.
- Setup software and hardware tasks for interfacing with the neato lidar.
- Fix issue decoding commands when packets do not contain the whole command by introducing a buffering stage. (known issue but now it surfaced as an actual problem)
- Add command for setting the downsample behavior (to only emit every nth scan frame, for performance reasons).
