### PR TITLE
feat(wip): implement EKF based SLAM using landmarks

### DIFF
--- a/slamrs/Cargo.lock
+++ b/slamrs/Cargo.lock
@@ -1942,6 +1942,7 @@ dependencies = [
  "graphics",
  "itertools",
  "kd-tree",
+ "log",
  "lstsq",
  "nalgebra 0.33.0",
  "pubsub",

--- a/slamrs/baseui/src/config.rs
+++ b/slamrs/baseui/src/config.rs
@@ -5,7 +5,7 @@ use common::node::{Node, NodeConfig};
 use pubsub::PubSub;
 use serde::Deserialize;
 use simulator::SimulatorNodeConfig;
-use slam::{GridMapSlamNodeConfig, IcpPointMapNodeConfig};
+use slam::{EKFLandmarkSlamNodeConfig, GridMapSlamNodeConfig, IcpPointMapNodeConfig};
 
 use crate::node::{
     controls::ControlsNodeConfig, frame_viz::FrameVizualizerNodeConfig,
@@ -44,6 +44,7 @@ pub enum NodeEnum {
     GridMapSlam(GridMapSlamNodeConfig),
     GaussianTest(GaussianNodeConfig),
     Splitter(SplitterNodeConfig),
+    EKFLandmarkSlam(EKFLandmarkSlamNodeConfig),
 }
 
 impl NodeEnum {
@@ -63,6 +64,7 @@ impl NodeEnum {
             GridMapSlam(c) => c.instantiate(pubsub),
             GaussianTest(c) => c.instantiate(pubsub),
             Splitter(c) => c.instantiate(pubsub),
+            EKFLandmarkSlam(c) => c.instantiate(pubsub),
         }
     }
 }

--- a/slamrs/baseui/src/node/frame_viz.rs
+++ b/slamrs/baseui/src/node/frame_viz.rs
@@ -11,11 +11,12 @@ use pubsub::{PubSub, Subscription};
 
 use graphics::shaperenderer::ShapeRenderer;
 use serde::Deserialize;
-use slam::{GridMapMessage, PointMap};
+use slam::{GridMapMessage, LandmarkMapMessage, PointMap};
 
 use super::visualize::{
-    GridMapVisualizeConfig, LandmarkObservationVisualizeConfig, ObservationVisualizeConfig,
-    PointMapVisualizeConfig, PoseVisualizeConfig, Visualize, VisualizeParametersUi,
+    GridMapVisualizeConfig, LandmarkMapMessageVisualizeConfig, LandmarkObservationVisualizeConfig,
+    ObservationVisualizeConfig, PointMapVisualizeConfig, PoseVisualizeConfig, Visualize,
+    VisualizeParametersUi,
 };
 
 pub struct FrameVizualizer {
@@ -148,6 +149,10 @@ enum VizType {
         topic: String,
         config: GridMapVisualizeConfig,
     },
+    LandmarkMap {
+        topic: String,
+        config: LandmarkMapMessageVisualizeConfig,
+    },
 }
 
 impl VizType {
@@ -181,6 +186,10 @@ impl VizType {
             )),
             VizType::GridMap { topic, config } => Box::new(SubscriptionVisualizer::new(
                 pubsub.subscribe::<GridMapMessage>(topic),
+                config.clone(),
+            )),
+            VizType::LandmarkMap { topic, config } => Box::new(SubscriptionVisualizer::new(
+                pubsub.subscribe::<LandmarkMapMessage>(topic),
                 config.clone(),
             )),
         }

--- a/slamrs/baseui/src/node/visualize.rs
+++ b/slamrs/baseui/src/node/visualize.rs
@@ -6,7 +6,7 @@ use graphics::{
     shaperenderer::ShapeRenderer,
 };
 use serde::Deserialize;
-use slam::{GridMapMessage, PointMap};
+use slam::{GridMapMessage, LandmarkMapMessage, PointMap};
 
 pub trait Visualize {
     type Parameters;
@@ -283,7 +283,7 @@ impl Visualize for GridMapMessage {
     }
 }
 
-//////////////// Implementation for Gaussian2D /////////////////
+//////////////// Implementation for LandmarkObsercations /////////////////
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(default)]
@@ -342,6 +342,44 @@ impl Visualize for LandmarkObservations {
             }
 
             sr.end();
+        }
+    }
+}
+
+//////////////// Implementation for LandmarkMapMessage /////////////////
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(default)]
+pub struct LandmarkMapMessageVisualizeConfig {
+    p: f32,
+}
+
+impl Default for LandmarkMapMessageVisualizeConfig {
+    fn default() -> Self {
+        Self { p: 0.95 }
+    }
+}
+
+impl VisualizeParametersUi for LandmarkMapMessageVisualizeConfig {
+    fn ui(&mut self, ui: &mut egui::Ui) {
+        ui.horizontal(|ui| {
+            ui.label("P: ");
+            ui.add(
+                Slider::new(&mut self.p, 0.001..=1.0)
+                    .step_by(0.001)
+                    .fixed_decimals(3),
+            );
+        });
+    }
+}
+
+impl Visualize for LandmarkMapMessage {
+    type Parameters = LandmarkMapMessageVisualizeConfig;
+    type Secondary = ();
+
+    fn visualize(&self, sr: &mut ShapeRenderer, c: &Self::Parameters, _: &Option<Self::Secondary>) {
+        for l in &self.landmarks {
+            sr.gaussian2d(&l.mean, &l.covariance, c.p);
         }
     }
 }

--- a/slamrs/common/src/robot.rs
+++ b/slamrs/common/src/robot.rs
@@ -119,24 +119,19 @@ pub struct Odometry {
     /// The distance in meters that the right wheel of the robot travelled since last odometry reading.
     pub distance_right: f32,
 
+    /// The distance between the two wheels of the robot in meters.
+    pub wheel_distance: f32,
+
     /// Distribution that describes how far the center has moved
     distribution_center: Normal,
     /// Distribution that describes the angle moved (in radians)
     distribution_theta: Normal,
 }
 
-pub const WHEEL_DISTANCE: f32 = 0.1;
-
-impl Default for Odometry {
-    fn default() -> Self {
-        Self::new(0.0, 0.0)
-    }
-}
-
 impl Odometry {
-    pub fn new(distance_left: f32, distance_right: f32) -> Self {
+    pub fn new(distance_left: f32, distance_right: f32, wheel_distance: f32) -> Self {
         let delta_center = ((distance_left + distance_right) / 2.0) as f64;
-        let delta_theta = ((distance_right - distance_left) / WHEEL_DISTANCE) as f64;
+        let delta_theta = ((distance_right - distance_left) / wheel_distance) as f64;
 
         // simple model for the expected variation in measurement vs world:
         // Some fixed (minimum) variation + a part proportional to the change in value
@@ -150,6 +145,7 @@ impl Odometry {
                 .expect("Create normal distribution for theta"),
             distance_left,
             distance_right,
+            wheel_distance,
         }
     }
 

--- a/slamrs/common/src/robot.rs
+++ b/slamrs/common/src/robot.rs
@@ -104,6 +104,10 @@ pub struct LandmarkObservation {
     pub angle: f32,
     /// Distance in meters to the observed landmark
     pub distance: f32,
+
+    /// An optional association ID which uniquely identifies the observed landmark.
+    /// This is mostly populated when using the simulator.
+    pub association: Option<usize>,
 }
 
 /// Observed (measured) motion of the left and right wheel

--- a/slamrs/config/landmarks.yaml
+++ b/slamrs/config/landmarks.yaml
@@ -53,9 +53,18 @@ nodes:
     topic_pose: "simulator/pose"
     config:
       
-  # - !Pose
-  #   topic: "robot/pose"
-  #   config:
-  #     color: [0.0, 1.0, 1.0]
-  #     radius: 0.1
+  - !LandmarkMap
+    topic: "slam/map"
+    config:
+      
+  - !Pose
+    topic: "slam/pose"
+    config:
+      color: [0.0, 1.0, 1.0]
+      radius: 0.1
         
+- !EKFLandmarkSlam
+  topic_observation_landmark: "robot/observation_odometry"
+  topic_pose: "slam/pose"
+  topic_map: "slam/map"
+  config:

--- a/slamrs/config/landmarks.yaml
+++ b/slamrs/config/landmarks.yaml
@@ -13,7 +13,7 @@ nodes:
     odometry: "robot/odometry"
 
 - !Simulator
-  running: true
+  running: false
   topic_observation_landmarks: "robot/observation_odometry"
   topic_pose: "simulator/pose"
   topic_command: "robot/command"

--- a/slamrs/neato/src/connection.rs
+++ b/slamrs/neato/src/connection.rs
@@ -31,6 +31,9 @@ pub struct RobotConnection {
     sub_command: Subscription<Command>,
 }
 
+/// The distance between the wheels of the robot
+static WHEEL_BASE: f32 = 0.2;
+
 enum State {
     Idle,
     Running {
@@ -269,7 +272,8 @@ fn stream<C: ConnectionMedium>(
                 RobotMessage::ScanFrame(scan_frame) => {
                     let parsed = frame::parse_frame(&scan_frame.scan_data)?;
                     println!("Received: {:?}", &scan_frame.rpm);
-                    let odometry = Odometry::new(scan_frame.odometry[0], scan_frame.odometry[1]);
+                    let odometry =
+                        Odometry::new(scan_frame.odometry[0], scan_frame.odometry[1], WHEEL_BASE);
                     pub_obs.publish(Arc::new((parsed.into(), odometry)));
                 }
                 RobotMessage::Pong => {

--- a/slamrs/simulator/src/sim.rs
+++ b/slamrs/simulator/src/sim.rs
@@ -177,7 +177,7 @@ impl Simulator {
 
                     // go through all the landmarks and find the ones that are in the field of view infrontof the robot
 
-                    for l in self.scene.read().landmarks() {
+                    for (i, l) in self.scene.read().landmarks().enumerate() {
                         let dist_sq = (self.pose.x - l.x).powi(2) + (self.pose.y - l.y).powi(2);
                         if dist_sq > self.parameters.scanner_range {
                             continue;
@@ -193,6 +193,7 @@ impl Simulator {
                                 + normal.sample(rng) as f32 * self.parameters.angle_uncertainty,
                             distance: dist_sq.sqrt()
                                 + normal.sample(rng) as f32 * self.parameters.distance_uncertainty,
+                            association: Some(i),
                         })
                     }
 

--- a/slamrs/simulator/src/sim.rs
+++ b/slamrs/simulator/src/sim.rs
@@ -41,10 +41,10 @@ pub struct SimParameters {
     /// Laser range scanner maximum distance in meters.
     pub(crate) scanner_range: f32,
 
-    /// The uncertainty for the sensor in the angle direction
+    /// The uncertainty for the sensor in the angle direction (radians)
     pub(crate) angle_uncertainty: f32,
 
-    /// The uncertainty for the sensor in the distance measurement
+    /// The uncertainty for the sensor in the distance measurement (meters)
     pub(crate) distance_uncertainty: f32,
 }
 
@@ -54,7 +54,7 @@ impl Default for SimParameters {
             wheel_base: 0.1,
             update_period: 0.2,
             scanner_range: 1.0,
-            angle_uncertainty: 0.05,
+            angle_uncertainty: 0.03,
             distance_uncertainty: 0.02,
         }
     }
@@ -115,6 +115,7 @@ impl Simulator {
                 let odometry = Odometry::new(
                     self.wheel_motion_accumulator.0,
                     self.wheel_motion_accumulator.1,
+                    self.parameters.wheel_base,
                 );
 
                 // reset the accumulator

--- a/slamrs/slam/Cargo.toml
+++ b/slamrs/slam/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = {workspace = true}
 eframe = {workspace = true}
 nalgebra = {workspace = true}
 serde = {workspace = true}
+log = {workspace = true}
 
 rand = {workspace = true}
 

--- a/slamrs/slam/src/landmark/ekf.rs
+++ b/slamrs/slam/src/landmark/ekf.rs
@@ -8,37 +8,254 @@ pub struct EKFLandmarkSlamConfig {}
 
 #[derive(Debug)]
 pub struct EKFLandmarkSlam {
-    landmarks: Vec<Landmark>,
+    // pose_mean: na::Vector3<f32>,
+    // pose_covariance: na::Matrix3<f32>,
+    state_mean: na::DVector<f32>,
+    state_covariance: na::DMatrix<f32>,
+    num_landmarks: usize,
+    landmark_seen: Vec<bool>,
+    // landmarks: Vec<Landmark>,
 }
 
 impl EKFLandmarkSlam {
     pub fn new(_config: &EKFLandmarkSlamConfig) -> Self {
+        let num_landmarks = 10;
+
+        // mean starts out as zero for both pose and pandmark positions
+        let state_mean = na::DVector::zeros(3 + 2 * num_landmarks);
+
+        // "infinite" covariance for landmarks
+        let mut state_covariance =
+            na::DMatrix::identity(3 + 2 * num_landmarks, 3 + 2 * num_landmarks) * 1000.0;
+
+        // covariance for the robot pose is zero
+        state_covariance[(0, 0)] = 0.0;
+        state_covariance[(1, 1)] = 0.0;
+        state_covariance[(2, 2)] = 0.0;
+
         // TODO
         Self {
-            landmarks: vec![
-                Landmark {
-                    mean: na::Vector2::new(0.0, 0.0),
-                    covariance: na::Matrix2::identity() * 0.1,
-                },
-                Landmark {
-                    mean: na::Vector2::new(1.0, 0.0),
-                    covariance: na::Matrix2::identity() * 0.1,
-                },
-            ],
+            state_mean,
+            state_covariance,
+            num_landmarks,
+            landmark_seen: vec![false; num_landmarks],
+            // pose_mean: na::Vector3::zeros(),
+            // pose_covariance: na::Matrix3::zeros(),
+            // landmarks: vec![
+            //     Landmark {
+            //         mean: na::Vector2::zeros(),
+            //         covariance: na::Matrix2::identity() * 1000.0, // "infinite" covariance
+            //     };
+            //     20
+            // ], // ,
+            //     Landmark {
+            //         mean: na::Vector2::new(1.0, 0.0),
+            //         covariance: na::Matrix2::identity() * 0.1,
+            //     },
+            // ],
         }
     }
 
-    pub fn update(&mut self, _observation: &LandmarkObservations, _odometry: Odometry) {
+    // fn landmark_mean(&self, landmark_index: usize) -> na::VectorView2<f32> {
+    //     assert!(landmark_index < self.num_landmarks);
+    //     self.state_mean.fixed_rows::<2>(3 + 2 * landmark_index)
+    // }
+
+    pub fn update(&mut self, observation: &LandmarkObservations, odometry: Odometry) {
         // todo
+
+        /////// Update the robot location using the motion model
+
+        let omega_dt = (odometry.distance_right - odometry.distance_left) / odometry.wheel_distance;
+        let v_dt = (odometry.distance_left + odometry.distance_right) / 2.0;
+
+        // Velocity-based motion model from : https://youtu.be/5Pu558YtjYM?list=PLgnQpQtFTOGQrZ4O5QzbIHgl3b1JHimN_&t=1849
+        let (gxytheta, gx_jacobian) = if omega_dt != 0.0 {
+            let v_over_omega = v_dt / omega_dt; // the delta t cancels out
+            let theta = self.state_mean[2];
+            let gxytheta = na::Vector3::new(
+                -v_over_omega * theta.sin() + v_over_omega * (theta + omega_dt).sin(),
+                v_over_omega * theta.cos() - v_over_omega * (theta + omega_dt).cos(),
+                omega_dt,
+            );
+            // conpute the Jacobian of the motion model (only affects the top 3x3 block of the covariance matrix)
+            let gx = na::Matrix3::new(
+                1.0,
+                0.0,
+                -v_over_omega * theta.cos() + v_over_omega * (theta + omega_dt).cos(),
+                0.0,
+                1.0,
+                -v_over_omega * theta.sin() + v_over_omega * (theta + omega_dt).sin(),
+                0.0,
+                0.0,
+                1.0,
+            );
+            (gxytheta, gx)
+        } else {
+            // no rotation, just straight line motion
+            let theta = self.state_mean[2];
+            let gxytheta = na::Vector3::new(v_dt * theta.cos(), v_dt * theta.sin(), 0.0);
+            let gx = na::Matrix3::new(
+                1.0,
+                0.0,
+                -v_dt * theta.sin(),
+                0.0,
+                1.0,
+                v_dt * theta.cos(),
+                0.0,
+                0.0,
+                1.0,
+            );
+            (gxytheta, gx)
+        };
+
+        // apply the motion model to get the new mean, wrap angle
+        let mut mu_bar = self.state_mean.clone();
+        mu_bar[0] += gxytheta[0];
+        mu_bar[1] += gxytheta[1];
+        mu_bar[2] = na::wrap(
+            mu_bar[2] + gxytheta[2],
+            -std::f32::consts::PI,
+            std::f32::consts::PI,
+        );
+
+        let mut g: na::DMatrix<f32> =
+            na::DMatrix::identity(3 + 2 * self.num_landmarks, 3 + 2 * self.num_landmarks);
+        g.fixed_view_mut::<3, 3>(0, 0).copy_from(&gx_jacobian);
+        let g = g;
+
+        // r is the motion noise (variance) in the motion model: x (m), y (m), theta (radians)
+        let sigma = na::Vector3::new(0.02, 0.02, 5.0_f32.to_radians());
+        let r = na::Matrix3::from_diagonal(&sigma.component_mul(&sigma));
+
+        // compute sigma bar (todo update blocks individually for better computational complexity, see video at 37:00)
+        let mut sigma_bar = &g * &self.state_covariance * g.transpose();
+        let mut a = sigma_bar.fixed_view_mut::<3, 3>(0, 0);
+        a += r;
+
+        //
+        ///// Do the update / correction step
+
+        for l in observation.landmarks.iter() {
+            // data association
+            let Some(landmark_idx) = l.association else {
+                continue;
+            };
+
+            if !self.landmark_seen[landmark_idx] {
+                self.landmark_seen[landmark_idx] = true;
+                log::info!("landmark seen for first time: {}", landmark_idx);
+
+                // initialize as if the landmark is exactly what we would expect
+                mu_bar[3 + 2 * landmark_idx] = mu_bar[0] + l.distance * (mu_bar[2] + l.angle).cos();
+                mu_bar[3 + 2 * landmark_idx + 1] =
+                    mu_bar[1] + l.distance * (mu_bar[2] + l.angle).sin();
+            }
+
+            // predict the observed landmark location
+
+            let dx = mu_bar[3 + 2 * landmark_idx] - mu_bar[0];
+            let dy = mu_bar[3 + 2 * landmark_idx + 1] - mu_bar[1];
+            let q = dx * dx + dy * dy;
+            let sqrt_q = q.sqrt();
+
+            // compute the expected observation
+            let z_bar = na::Vector2::new(sqrt_q, dy.atan2(dx) - mu_bar[2]);
+            let z = na::Vector2::new(l.distance, l.angle);
+
+            // compute the jacobian of the expected observation wrt the state and the location of
+            // the landmark
+
+            let h_jacobian_low = na::Matrix2x5::new(
+                -sqrt_q * dx,
+                -sqrt_q * dy,
+                0.0,
+                sqrt_q * dx,
+                sqrt_q * dy,
+                dy,
+                -dx,
+                -q,
+                -dy,
+                dx,
+            );
+
+            // transformation matrix to get to the full state
+            let fxj = {
+                let mut fxj = na::DMatrix::zeros(5, 3 + 2 * self.num_landmarks);
+                fxj[(0, 0)] = 1.0;
+                fxj[(1, 1)] = 1.0;
+                fxj[(2, 2)] = 1.0;
+                fxj[(3, 3 + 2 * landmark_idx)] = 1.0;
+                fxj[(4, 3 + 2 * landmark_idx + 1)] = 1.0;
+                fxj
+            };
+
+            let h_jacobian = h_jacobian_low * fxj;
+
+            // variance in the observation: distance (meters) and angle (radians)
+            let sigma = na::Matrix2::from_diagonal(&na::Vector2::new(0.03, 3.0_f32.to_radians()));
+            let q = na::Matrix2::from(sigma.component_mul(&sigma));
+
+            // compute the kalman gain for this observation
+            let k = &sigma_bar
+                * h_jacobian.transpose()
+                * (&h_jacobian * &sigma_bar * h_jacobian.transpose() + q)
+                    .try_inverse()
+                    .unwrap();
+
+            // compute the diff and normalize the angle
+            let mut diff = z - z_bar;
+            diff[1] = na::wrap(diff[1], -std::f32::consts::PI, std::f32::consts::PI);
+
+            mu_bar += &k * diff;
+
+            // wrap angle
+            mu_bar[2] = na::wrap(mu_bar[2], -std::f32::consts::PI, std::f32::consts::PI);
+
+            // update the covariance
+            sigma_bar =
+                (na::DMatrix::identity(3 + 2 * self.num_landmarks, 3 + 2 * self.num_landmarks)
+                    - &k * &h_jacobian)
+                    * &sigma_bar;
+        }
+
+        self.state_mean = mu_bar;
+        self.state_covariance = sigma_bar;
     }
 
     pub fn estimated_pose(&self) -> Pose {
-        // TODO
-        Pose::default()
+        Pose {
+            x: self.state_mean[0],
+            y: self.state_mean[1],
+            theta: self.state_mean[2],
+        }
     }
 
-    pub fn estimated_landmarks(&self) -> &[Landmark] {
-        &self.landmarks
+    pub fn estimated_landmarks(&self) -> Vec<Landmark> {
+        let mut l = self
+            .landmark_seen
+            .iter()
+            .enumerate()
+            .filter(|(_, &seen)| seen)
+            .map(|(i, _)| {
+                let x = self.state_mean[3 + 2 * i];
+                let y = self.state_mean[3 + 2 * i + 1];
+                let mean = na::Vector2::new(x, y);
+                let covariance = self
+                    .state_covariance
+                    .fixed_view::<2, 2>(3 + 2 * i, 3 + 2 * i);
+                Landmark {
+                    mean,
+                    covariance: covariance.into(),
+                }
+            })
+            .collect::<Vec<Landmark>>();
+        // TODO: remove when we have way to send an estimated pose with uncertainty
+        l.push(Landmark {
+            mean: self.state_mean.fixed_rows::<2>(0).into(),
+            covariance: self.state_covariance.fixed_view::<2, 2>(0, 0).into(),
+        });
+        l
     }
 }
 

--- a/slamrs/slam/src/landmark/ekf.rs
+++ b/slamrs/slam/src/landmark/ekf.rs
@@ -1,0 +1,49 @@
+use common::robot::{LandmarkObservations, Odometry, Pose};
+
+use nalgebra as na;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct EKFLandmarkSlamConfig {}
+
+#[derive(Debug)]
+pub struct EKFLandmarkSlam {
+    landmarks: Vec<Landmark>,
+}
+
+impl EKFLandmarkSlam {
+    pub fn new(_config: &EKFLandmarkSlamConfig) -> Self {
+        // TODO
+        Self {
+            landmarks: vec![
+                Landmark {
+                    mean: na::Vector2::new(0.0, 0.0),
+                    covariance: na::Matrix2::identity() * 0.1,
+                },
+                Landmark {
+                    mean: na::Vector2::new(1.0, 0.0),
+                    covariance: na::Matrix2::identity() * 0.1,
+                },
+            ],
+        }
+    }
+
+    pub fn update(&mut self, _observation: &LandmarkObservations, _odometry: Odometry) {
+        // todo
+    }
+
+    pub fn estimated_pose(&self) -> Pose {
+        // TODO
+        Pose::default()
+    }
+
+    pub fn estimated_landmarks(&self) -> &[Landmark] {
+        &self.landmarks
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Landmark {
+    pub mean: na::Vector2<f32>,
+    pub covariance: na::Matrix2<f32>,
+}

--- a/slamrs/slam/src/landmark/mod.rs
+++ b/slamrs/slam/src/landmark/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod ekf;
+pub(crate) mod node;

--- a/slamrs/slam/src/landmark/node.rs
+++ b/slamrs/slam/src/landmark/node.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use common::{
+    node::{Node, NodeConfig},
+    robot::{LandmarkObservations, Odometry, Pose},
+};
+use eframe::egui;
+
+use pubsub::{Publisher, Subscription};
+use serde::Deserialize;
+
+use super::ekf::{EKFLandmarkSlam, EKFLandmarkSlamConfig, Landmark};
+
+pub struct EKFLandmarkSlamNode {
+    sub_obs_odom: Subscription<(LandmarkObservations, Odometry)>,
+    pub_pose: Publisher<Pose>,
+    pub_map: Publisher<LandmarkMapMessage>,
+    slam: EKFLandmarkSlam,
+    config: EKFLandmarkSlamConfig,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct EKFLandmarkSlamNodeConfig {
+    topic_pose: String,
+    topic_observation_landmark: String,
+    topic_map: String,
+    config: EKFLandmarkSlamConfig,
+}
+
+impl NodeConfig for EKFLandmarkSlamNodeConfig {
+    fn instantiate(&self, pubsub: &mut pubsub::PubSub) -> Box<dyn Node> {
+        Box::new(EKFLandmarkSlamNode {
+            sub_obs_odom: pubsub.subscribe(&self.topic_observation_landmark),
+            pub_pose: pubsub.publish(&self.topic_pose),
+            pub_map: pubsub.publish(&self.topic_map),
+            slam: EKFLandmarkSlam::new(&self.config),
+            config: self.config.clone(),
+        })
+    }
+}
+
+impl Node for EKFLandmarkSlamNode {
+    fn update(&mut self) {
+        if let Some(o) = self.sub_obs_odom.try_recv() {
+            self.slam.update(&o.0, o.1);
+
+            self.pub_pose.publish(Arc::new(self.slam.estimated_pose()));
+
+            self.pub_map.publish(Arc::new(LandmarkMapMessage {
+                landmarks: self.slam.estimated_landmarks().to_vec(),
+            }));
+        }
+    }
+
+    fn draw(&mut self, ui: &egui::Ui, _world: &mut common::world::WorldObj<'_>) {
+        egui::Window::new("EKF Landmark Slam").show(ui.ctx(), |ui| {
+            ui.label("[WIP]");
+        });
+    }
+}
+
+pub struct LandmarkMapMessage {
+    pub landmarks: Vec<Landmark>,
+}

--- a/slamrs/slam/src/landmark/node.rs
+++ b/slamrs/slam/src/landmark/node.rs
@@ -46,8 +46,11 @@ impl Node for EKFLandmarkSlamNode {
 
             self.pub_pose.publish(Arc::new(self.slam.estimated_pose()));
 
+            let estimated_landmarks = self.slam.estimated_landmarks();
+
+            // log::info!("Estimated landmarks: {:?}", estimated_landmarks);
             self.pub_map.publish(Arc::new(LandmarkMapMessage {
-                landmarks: self.slam.estimated_landmarks().to_vec(),
+                landmarks: estimated_landmarks,
             }));
         }
     }

--- a/slamrs/slam/src/landmark/node.rs
+++ b/slamrs/slam/src/landmark/node.rs
@@ -19,6 +19,7 @@ pub struct EKFLandmarkSlamNode {
     pub_pose: Publisher<Pose>,
     pub_map: Publisher<LandmarkMapMessage>,
     slam: EKFLandmarkSlam,
+    #[allow(dead_code)]
     config: EKFLandmarkSlamConfig,
 }
 

--- a/slamrs/slam/src/lib.rs
+++ b/slamrs/slam/src/lib.rs
@@ -1,9 +1,12 @@
 mod grid;
 mod icp;
+mod landmark;
 mod pointmap;
 
 pub use pointmap::{IcpPointMapNode, IcpPointMapNodeConfig, PointMap};
 
+pub use grid::map::{Cell, GridData};
 pub use grid::node::{GridMapMessage, GridMapSlamNode, GridMapSlamNodeConfig};
 
-pub use grid::map::{Cell, GridData};
+pub use landmark::ekf::{EKFLandmarkSlamConfig, Landmark};
+pub use landmark::node::{EKFLandmarkSlamNode, EKFLandmarkSlamNodeConfig, LandmarkMapMessage};


### PR DESCRIPTION
this implements a simple version of EKF-based SLAM using landmarks. It is a work-in-progress version since it does not strictly follow the algorithm from the probabilistic robotics book, and so this is mostly merged to have something available at all.