### PR TITLE
fix: replace transmute with now const `from_bits`

### DIFF
--- a/slamrs/graphics/src/primitiverenderer.rs
+++ b/slamrs/graphics/src/primitiverenderer.rs
@@ -333,10 +333,8 @@ impl Color {
 
     pub const fn rgba_u8(r: u8, g: u8, b: u8, a: u8) -> Self {
         let colori = ((a as u32) << 24) | ((b as u32) << 16) | ((g as u32) << 8) | (r as u32);
-
-        // bits: f32::from_bits(colori), // (not const yet...)
         Self {
-            bits: unsafe { core::mem::transmute::<u32, f32>(colori) },
+            bits: f32::from_bits(colori),
         }
     }
 

--- a/slamrs/slam/src/grid/map.rs
+++ b/slamrs/slam/src/grid/map.rs
@@ -6,22 +6,19 @@ use common::math::{LogOdds, LogProbability, Probability};
 
 #[derive(Clone)]
 pub struct Map {
-    /** the position of this map in the world (lower left corner) */
+    /// the position of this map in the world (lower left corner)
     position: Vector2<f32>,
 
-    /** the size of the map in world coordinates */
+    /// the size of the map in world coordinates
     world_size: Vector2<f32>,
 
-    /** the size of the map in cells */
+    /// the size of the map in cells
     grid_size: Vector2<usize>,
 
-    /** array for storing the probability data */
-    // double[] probData;
-
-    /** the resolution of this GridMap, given in meters per cell */
+    /// the resolution of this GridMap, given in meters per cell
     resolution: f32,
 
-    // Data vectors
+    /// Data vectors
     odds: GridData<LogOdds>,
 }
 

--- a/slamrs/slam/src/grid/ray.rs
+++ b/slamrs/slam/src/grid/ray.rs
@@ -18,7 +18,6 @@ impl GridRayIterator {
     /// Create an iterator to iterate over the line specified. The start and end points are specified in grid coordinates,
     /// with the origin at the bottom left. The iterator values correspond to the center of each cell that is visited
     /// along the ray from start to end point.
-
     pub fn new(
         x0: f32,
         y0: f32,
@@ -30,7 +29,6 @@ impl GridRayIterator {
         let delta = Vector2::new(x1 - x0, y1 - y0).abs();
 
         // set up stuff
-
         let x = x0.floor() as isize;
         let y = y0.floor() as isize;
 


### PR DESCRIPTION
`f32::from_bits` is now const in rust `1.83` and the use of `transmute` causes a compilation error. This fixes that!